### PR TITLE
Fix undefined variable in image resizing

### DIFF
--- a/omnigen2/pipelines/image_processor.py
+++ b/omnigen2/pipelines/image_processor.py
@@ -124,6 +124,8 @@ class OmniGen2ImageProcessor(VaeImageProcessor):
                 max_side_length_ratio = max_side_length / height
             else:
                 max_side_length_ratio = max_side_length / width
+        else:
+            max_side_length_ratio = 1.0
         
         cur_pixels = height * width
         max_pixels_ratio = (max_pixels / cur_pixels) ** 0.5


### PR DESCRIPTION
## Summary
- prevent `UnboundLocalError` in `OmniGen2ImageProcessor.get_new_height_width`

## Testing
- `python -m py_compile omnigen2/pipelines/image_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_685fca9bff04832da37433ceb145ad18