### PR TITLE
Fix model name in warning

### DIFF
--- a/omnigen2/pipelines/omnigen2/pipeline_omnigen2.py
+++ b/omnigen2/pipelines/omnigen2/pipeline_omnigen2.py
@@ -310,7 +310,7 @@ class OmniGen2Pipeline(DiffusionPipeline):
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
             removed_text = self.processor.tokenizer.batch_decode(untruncated_ids[:, max_sequence_length - 1 : -1])
             logger.warning(
-                "The following part of your input was truncated because Gemma can only handle sequences up to"
+                "The following part of your input was truncated because Qwen2.5-VL can only handle sequences up to"
                 f" {max_sequence_length} tokens: {removed_text}"
             )
 


### PR DESCRIPTION
## Summary
- update the truncation warning to reference Qwen2.5-VL instead of Gemma

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_685fcf0f2974832da46e6d199f839e93